### PR TITLE
Fix Meilisearch crash in windows docker

### DIFF
--- a/Meilisearch4TelegramSearchCKJ/src/config/env.py
+++ b/Meilisearch4TelegramSearchCKJ/src/config/env.py
@@ -153,5 +153,4 @@ INDEX_CONFIG = {
         "maxTotalHits": 500
     },
     "searchCutoffMs": None,
-    "localizedAttributes": None
 } if not os.getenv("INDEX_CONFIG") else ast.literal_eval(os.getenv("INDEX_CONFIG"))

--- a/docker-compose-windows.yml
+++ b/docker-compose-windows.yml
@@ -1,0 +1,27 @@
+#Add Windows Docker support
+
+services:
+  # The Database
+  meilisearch:
+    image: getmeili/meilisearch:latest
+    container_name: meili-db
+    restart: unless-stopped
+    environment:
+      - MEILI_MASTER_KEY=myMasterKey123
+    volumes:
+      - ./meili_data:/meili_data
+    ports:
+      - "7700:7700"
+
+  # The Bot
+  telegramsearchckj:
+    image: ghcr.io/clionertr/meilisearch4telegramsearchckj:latest
+    container_name: telegram-bot
+    restart: unless-stopped
+    depends_on:
+      - meilisearch
+    volumes:
+      - ./env.py:/app/Meilisearch4TelegramSearchCKJ/src/config/env.py
+      - ./session:/app/Meilisearch4TelegramSearchCKJ/src/session
+    environment:
+      - TZ=Asia/Shanghai


### PR DESCRIPTION
大佬你好，我解决了些我在windows的docker部署时遇到的问题。
- Added a docker-compose.yml that works on Windows (removed host network mode).

- Removed localizedAttributes from the config, which was causing Meilisearch to crash on startup with "Invalid Request".

通过huggingface部署的话也会在step2，即部署本项目那里出现runtime error，想问大佬打算修吗？
超棒的插件(˶˃ ᵕ ˂˶)